### PR TITLE
IBAN validation, remember rejected content

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -8,13 +8,14 @@ define('TEMPLATES_DIR', BASE_DIR . 'templates/');
 define('EMAIL_TO_ADDRESS', 'addressee@something.org');
 define('EMAIL_TO_NAME', 'R. ecipient');
 define('EMAIL_SUBJECT_BASE', 'Receipt:');
+define('EMAIL_FIRST_NAME', 'Roderick');
 
 // Mailgun settings
 define('EMAIL_API_KEY', '');
 define('EMAIL_DOMAIN', 'something.org');
 
 // Define upload restrictions
-define('FILE_MAX_FILESIZE', 100000000);
+define('FILE_MAX_FILESIZE', 20971520); // 20 MiB
 $allowed_filetypes  =
         array(
 				'jpg' => 'image/jpeg',

--- a/index.php
+++ b/index.php
@@ -11,8 +11,8 @@ use Mailgun\Mailgun;
 $header      = file_get_contents(TEMPLATES_DIR . 'header.html'      );
 $footer      = file_get_contents(TEMPLATES_DIR . 'footer.html'      );
 $confirm     = file_get_contents(TEMPLATES_DIR . 'confirm.html'     );
-$form        = file_get_contents(TEMPLATES_DIR . 'form.html'        );
 $form_header = file_get_contents(TEMPLATES_DIR . 'form_header.html' );
+$form        = 					 TEMPLATES_DIR . 'form.php'          ;
 
 // Check if all templates got loaded succesfully.
 // If not throw an error.
@@ -22,7 +22,7 @@ if ( $header && $footer && $form && $confirm &&$form_header ) {
 	if ( empty($_POST) ) {
 		echo $header;
 		echo $form_header;
-		eval($form);
+		require $form;
 		echo $footer;
 	}
 	// There is POST data, a submission has been made.
@@ -83,7 +83,7 @@ if ( $header && $footer && $form && $confirm &&$form_header ) {
 						echo alertMessage("Je hebt een fout gemaakt, probeer het opnieuw.");
 				}
 			}
-			eval($form);
+			require $form;
 			echo $footer;
 		}
 	}

--- a/index.php
+++ b/index.php
@@ -58,23 +58,23 @@ if ( $header && $footer && $form && $confirm &&$form_header ) {
 						echo alertMessage("Vul je naam in.");
 						break;
 					case "email":
-						echo alertMessage("Email-address niet geldig.");
+						echo alertMessage("Emailadres niet geldig.");
 						break;
 					case "totalamount":
 						echo alertMessage("Het bedrag moet een geldig cijfer zijn.");
 						break;
 					case "description":
-						echo alertMessage("Vermeld wat je gekocht hebt");
+						echo alertMessage("Vermeld wat je gekocht hebt.");
 						break;
 					case "purpose":
-						echo alertMessage("Vermeld waarvoor je het gekocht hebt");
+						echo alertMessage("Vermeld waarvoor je het gekocht hebt.");
 						break;
 					case "bank-account":
-						echo alertMessage("Vul je rekeningnummer in");
+						echo alertMessage("Ongeldig rekeningnummer.");
 						break;
 					case "ticket":
 						// echo alertMessage("Het bonnetje kan maximaal 2MB groot zijn. Alleen .pdf, .jpg, .gif en .png bestanden mogen worden geupload");
-						echo alertMessage("Het bonnetje kan maximaal 10MB groot zijn. Alleen .pdf, .png, .jpg en .gif bestanden mogen worden geupload");
+						echo alertMessage("Het bonnetje kan maximaal 10MB groot zijn. Alleen .pdf, .png, .jpg en .gif bestanden mogen worden geupload.");
 						break;
 					case "accept-tos":
 						echo alertMessage("Je moet alles eerst checken voordat je een declaratie kan doen.");
@@ -167,9 +167,15 @@ function validateIBAN($IBAN) {
 	return bcmod($transliterated, "97") == "1"; // Magic IBAN constants
 }
 
-function refill($field) {
-	if (isset($_POST[$field]))
-		return 'value="'. $_POST[$field] . '"';
+// Provides escaping and wrapping in value='' for values that failed validation.
+// value=''-wrapping is controlled by $attribute.
+function refill($field, $attribute=true) {
+	if (isset($_POST[$field])) {
+		$fill = htmlspecialchars($_POST[$field], ENT_QUOTES | ENT_HTML5); // Replaces ', ", <, >, &
+		if ($attribute)
+			$fill = 'value="'. $fill .'"';
+		return $fill;
+	}
 	return "";
 }
 

--- a/index.php
+++ b/index.php
@@ -10,9 +10,9 @@ use Mailgun\Mailgun;
 // Load templates
 $header      = file_get_contents(TEMPLATES_DIR . 'header.html'      );
 $footer      = file_get_contents(TEMPLATES_DIR . 'footer.html'      );
-$confirm     = file_get_contents(TEMPLATES_DIR . 'confirm.html'     );
+$confirm     =                   TEMPLATES_DIR . 'confirm.php'       ;
 $form_header = file_get_contents(TEMPLATES_DIR . 'form_header.html' );
-$form        = 					 TEMPLATES_DIR . 'form.php'          ;
+$form        =                   TEMPLATES_DIR . 'form.php'          ;
 
 // Check if all templates got loaded succesfully.
 // If not throw an error.
@@ -40,7 +40,7 @@ if ( $header && $footer && $form && $confirm &&$form_header ) {
 					== count( $validation_status ) ) {
 			handleSubmit($_POST, $_FILES['ticket']);
 			echo $header;
-			echo $confirm;
+			require $confirm;
 		}
 		else {
 			// TODO: Show the relevant errors according to the
@@ -287,15 +287,15 @@ function handleSubmit($post, $file) {
 	// through Mailgun
 	$mgClient = new Mailgun(EMAIL_API_KEY);
 	$mgClient->sendMessage(EMAIL_DOMAIN, array(
-		'from'    	=> $post['email'],
-		'to'      	=> EMAIL_TO_ADDRESS,
-		'subject' 	=> EMAIL_SUBJECT_BASE . $post['purpose'],
+			'from'    	=> $post['email'],
+			'to'      	=> EMAIL_TO_ADDRESS,
+			'subject' 	=> EMAIL_SUBJECT_BASE . $post['purpose'],
 
-		'o:tracking' 	=> false,
-                'o:tag'         => array('digidecs'),
-
-                'text'          => $mail_body
-        ), array(
-                'attachment'    => array( $file_name ))
-        );
+			'o:tracking' 	=> false,
+			'o:tag'         => array('digidecs'),
+			'text'          => $mail_body
+		),
+		array(
+			'attachment'    => array( $file_name ))
+		);
 }

--- a/index.php
+++ b/index.php
@@ -73,8 +73,8 @@ if ( $header && $footer && $form && $confirm &&$form_header ) {
 						echo alertMessage("Ongeldig rekeningnummer.");
 						break;
 					case "ticket":
-						// echo alertMessage("Het bonnetje kan maximaal 2MB groot zijn. Alleen .pdf, .jpg, .gif en .png bestanden mogen worden geupload");
-						echo alertMessage("Het bonnetje kan maximaal 10MB groot zijn. Alleen .pdf, .png, .jpg en .gif bestanden mogen worden geupload.");
+						$maxsize = (FILE_MAX_FILESIZE / 2**20) . "MB";
+						echo alertMessage("Het bonnetje kan maximaal $maxsize groot zijn. Alleen .pdf, .png, en .jpg bestanden mogen worden geupload.");
 						break;
 					case "accept-tos":
 						echo alertMessage("Je moet alles eerst checken voordat je een declaratie kan doen.");
@@ -247,16 +247,15 @@ function alertMessage($string) {
 // with the ticket attached.
 function handleSubmit($post, $file) {
 	// Build the message body
+	$treasurer = EMAIL_FIRST_NAME;
 	$mail_body      =
-		"Hoi Yorick,\n\n" .
+		"Hoi $treasurer,\n\n" .
 
 		"Ik heb zojuist het DigiDecs formulier ingevuld. " .
 		"Dit zijn mijn gegevens.\n\n" .
 
 		"Naam: {$post['name']}\n" .
 		"Email: {$post['email']}\n" .
-		"Woonplaats: {$post['city']}\n" .
-		"Datum aankoop: {$post['date']}\n" .
 		"Totaalbedrag: {$post['totalamount']}\n" .
 		"Wat: {$post['description']}\n" .
 		"Waarvoor: {$post['purpose']}\n" .

--- a/index.php
+++ b/index.php
@@ -155,7 +155,7 @@ function transnumerate($input) {
 // Validate IBAN using regexp
 function validateIBAN($IBAN) {
 	// Validate layout
-	if(!preg_match('/([a-zA-Z]{2}[0-9]{2})[a-zA-Z]{4}[0-9]{10}/', $IBAN, $matches))
+	if(!preg_match('/([a-zA-Z]{2}[0-9]{2})([a-zA-Z]{4}[0-9]{10})/', $IBAN, $matches))
 		return false;
 
 	// Move country code and checksum to end

--- a/templates/confirm.html
+++ b/templates/confirm.html
@@ -1,6 +1,0 @@
-<div class="panel-heading">
-	<h3 class="panel-title">Great success!</h3>
-</div>
-<div class="panel-body">
-	<p>Je aanvraag is onderweg naar onze penningmeester! Je hoeft zelf verder niets te doen. Als je na 7 dagen nog steeds je geld niet terug hebt gekregen, kan je contact opnemen via <a href="mailto:penningmeester@svsticky.nl">penningmeester@svsticky.nl</a>
-</div>

--- a/templates/confirm.php
+++ b/templates/confirm.php
@@ -1,0 +1,6 @@
+<div class="panel-heading">
+	<h3 class="panel-title">Great success!</h3>
+</div>
+<div class="panel-body">
+<p>Je aanvraag is onderweg naar onze penningmeester! Je hoeft zelf verder niets te doen. Als je na 7 dagen nog steeds je geld niet terug hebt gekregen, kan je contact opnemen via <a href="mailto:<?php echo EMAIL_TO_ADDRESS; ?>"><?php echo EMAIL_TO_ADDRESS; ?></a>
+</div>

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,17 +1,23 @@
 	<form role="form" action="index.php" method="post" enctype="multipart/form-data" id="digidecs-form">
 		<div class="form-group">
 			<label for="name">Naam<sup>*</sup></label>
-			<input type="text" class="form-control" id="name" name="name" placeholder="Secretaris" required>
+			<input type="text" class="form-control" id="name" name="name" placeholder="Secretaris"
+			<?php echo refill("name"); ?>
+			required>
 		</div>
 
                 <div class="form-group">
                         <label for="bank-account">IBAN<sup>*</sup></label>
-                        <input id="bank-account" name="bank-account" type="text" class="form-control" placeholder="NL11INGB012345678" required>
+						<input id="bank-account" name="bank-account" type="text" class="form-control" placeholder="NL13TEST0123456789"
+						<?php echo refill("bank-account"); ?>
+						required>
                 </div>
 
 		<div class="form-group">
 			<label for="email">E-mailadres<sup>*</sup></label>
-			<input type="email" class="form-control" id="email" name="email" placeholder="gigantischebaas@svsticky.nl" required>
+			<input type="email" class="form-control" id="email" name="email" placeholder="gigantischebaas@svsticky.nl"
+			<?php echo refill("email"); ?>
+			required>
 		</div>
 
 		<div class="form-group">
@@ -19,18 +25,21 @@
 			<div class="input-group">
 				<span class="input-group-addon">&euro;</span>
 				<input id="totalamount" name="totalamount" type="text" class="form-control" placeholder="9999.00" required pattern="[-+]?[0-9]*[.]?[0-9]+" oninvalid="setCustomValidity('Only use digits and separate them with a dot (.) if needed.')"
-    onchange="try{setCustomValidity('')}catch(e){}">
+	onchange="try{setCustomValidity('')}catch(e){}"
+				<?php echo refill("totalamount"); ?>>
 			</div>
 		</div>
 
 		<div class="form-group">
 			<label for="description">Wat heb je gekocht?<sup>*</sup></label>
-			<input id="description" name="description" type="text" class="form-control" placeholder="Graafmachine" required>
+			<input id="description" name="description" type="text" class="form-control" placeholder="Graafmachine"
+			<?php echo refill("description"); ?> required>
 		</div>
 
 		<div class="form-group">
 			<label for="purpose">Waarvoor/welke commissie?<sup>*</sup></label>
-			<input id="purpose" name="purpose" type="text" class="form-control" placeholder="Bestuur, lul!" required>
+			<input id="purpose" name="purpose" type="text" class="form-control" placeholder="Bestuur, lul!"
+			<?php echo refill("purpose"); ?> required>
 		</div>
 
 		<div class="form-group">
@@ -44,9 +53,9 @@
 
 		<div class="form-group">
 			<label for="remarks">Opmerkingen</label>
-			<textarea name="remarks" class="form-control" rows="3" type="textarea" id="remarks"></textarea>
+			<textarea name="remarks" class="form-control" rows="3" type="textarea" id="remarks"><?php echo refill("remarks"); ?></textarea>
 		</div>
-		
+
 		<div class="form-group">
 			<label for="accept-tos">
 				<input type="checkbox" name="accept-tos" id="accept-tos" required> Ik heb alles gecheckt en naar waarheid ingevuld<sup>*</sup>

--- a/templates/form.php
+++ b/templates/form.php
@@ -53,9 +53,7 @@
 
 		<div class="form-group">
 			<label for="remarks">Opmerkingen</label>
-			<textarea name="remarks" class="form-control" rows="3" type="textarea" id="remarks">
-			<?php if (isset($_POST['remarks'])) echo $_POST['remarks']; ?>
-			</textarea>
+			<textarea name="remarks" class="form-control" rows="3" type="textarea" id="remarks"><?php if (isset($_POST['remarks'])) echo $_POST['remarks']; ?></textarea>
 		</div>
 
 		<div class="form-group">

--- a/templates/form.php
+++ b/templates/form.php
@@ -62,6 +62,6 @@
 			</label>
 		</div>
 		<p>Velden met een <sup>*</sup> zijn verplicht</p>
-		<input type="submit" class="btn btn-success" value="Ik wil mijn geld terug!">
+		<input type="submit" class="btn btn-success" value="Geef geld!">
 	</form>
 </div>

--- a/templates/form.php
+++ b/templates/form.php
@@ -62,6 +62,6 @@
 			</label>
 		</div>
 		<p>Velden met een <sup>*</sup> zijn verplicht</p>
-		<input type="submit" class="btn btn-default">
+		<input type="submit" class="btn btn-success" value="Ik wil mijn geld terug!">
 	</form>
 </div>

--- a/templates/form.php
+++ b/templates/form.php
@@ -53,7 +53,9 @@
 
 		<div class="form-group">
 			<label for="remarks">Opmerkingen</label>
-			<textarea name="remarks" class="form-control" rows="3" type="textarea" id="remarks"><?php echo refill("remarks"); ?></textarea>
+			<textarea name="remarks" class="form-control" rows="3" type="textarea" id="remarks">
+			<?php if (isset($_POST['remarks'])) echo $_POST['remarks']; ?>
+			</textarea>
 		</div>
 
 		<div class="form-group">

--- a/templates/form.php
+++ b/templates/form.php
@@ -53,7 +53,7 @@
 
 		<div class="form-group">
 			<label for="remarks">Opmerkingen</label>
-			<textarea name="remarks" class="form-control" rows="3" type="textarea" id="remarks"><?php if (isset($_POST['remarks'])) echo $_POST['remarks']; ?></textarea>
+			<textarea name="remarks" class="form-control" rows="3" type="textarea" id="remarks"><?php echo refill('remarks', false); ?></textarea>
 		</div>
 
 		<div class="form-group">

--- a/templates/form.php
+++ b/templates/form.php
@@ -46,7 +46,7 @@
 			<label for="ticket">Bonnetje uploaden<sup>*</sup></label>
 			<input type="hidden" name="MAX_FILE_SIZE" value="10485760">
 			<input name="ticket" type="file" id="ticket" required>
-			<p class="help-block">Maximale grootte is 10MB. Alleen .pdf, .jpg, .gif en .png bestanden.</p>
+			<p class="help-block">Maximale grootte is <?php echo FILE_MAX_FILESIZE / 2 ** 20; ?>MB. Alleen .pdf, .jpg, en .png bestanden.</p>
 
                         <p class="help-block">Zorg dat de datum, het (btw) bedrag en de verschillende producten of diensten goed leesbaar zijn.</p>
 		</div>


### PR DESCRIPTION
Fixes #7

IBAN validation works, all entries with invalid IBAN-numbers (test: NL00TEST0123456789, valid is NL13TEST0123456789) are rejected, and the contents of the form are kept as well (to ease the process of accepting you're wrong) so that's nice.