### PR TITLE
New 11-test remainder calculation + lowercase handling

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -146,16 +146,25 @@ interface Data {
 }
 
 function checkIBAN(iban: string): boolean {  
-  return /^([a-zA-Z]{2}[0-9]{2})([a-zA-Z]{4}[0-9]{10})$/.test(iban);
+  // Tested with:
+  // GB33BUKB20201555555555 (correct)
+  // GB94BARC10201530093459 (correct)
+  // gB94BARC10201530093459 (correct, evaluates to its uppercase equivalent)
+  // GB94BARC20201530093459 (incorrect checksum)
+  iban = iban.toUpperCase();
+  const ibanRegex = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}$/;
+  if (!ibanRegex.test(iban)) {
+    return false;
+  }
 
-  // TODO broken
-  // const numericIban = (iban.slice(4) + iban.slice(0, 4))
-  //   .replace(/[A-Z]/g, char => (char.charCodeAt(0) - 55).toString()); // 11-test
-  // const remainder = numericIban
-  //   .split('')
-  //   .map((acc, digit) => (Number.parseInt(acc), digit))
-  //   .reduce((acc, digit) => (acc + digit) % 97, 0);
-  // return remainder === 1;
+  // ISO/IEC 7064:2003
+  // Convert IBAN to numeric representation (rearrange and replace letter with corresponding numeric value)
+  const numericIban = (iban.slice(4) + iban.slice(0,4))
+  .replace(/[A-Z]/g, char => (parseInt(char, 36)).toString());
+  // Match only sequences of 1-7 digits, convert each to number and add, then take result mod 97.
+  const remainder = numericIban
+    .match(/\d{1,7}/g)?.reduce((acc, block) => Number(acc + block) % 97, 0); 
+  return remainder===1;
 }
 
 export default defineComponent({


### PR DESCRIPTION
Previous 11-test had issues due to taking sequences into account that were too long. The remainder calculation is different now, and should work correctly.
Also, instead of allowing lowercase values to be parsed to the backend we just evaluate them to uppercase.